### PR TITLE
cbindgen: initial commit

### DIFF
--- a/cbindgen/.footprint
+++ b/cbindgen/.footprint
@@ -1,0 +1,3 @@
+drwxr-xr-x	root/root	usr/
+drwxr-xr-x	root/root	usr/bin/
+-rwxr-xr-x	root/root	usr/bin/cbindgen

--- a/cbindgen/Pkgfile
+++ b/cbindgen/Pkgfile
@@ -1,0 +1,23 @@
+# Description: Generate C bindings from rust code
+# URL: https://github.com/eqrion/cbindgen
+# Maintainer: Danny Rawlins, crux at romster dot me
+# Arch Maintainer: CRUX-ARM System Team, devel at crux-arm dot nu
+# Depends on: rust
+# Optional: sccache
+
+name=cbindgen
+version=0.24.3
+release=1
+source=(https://github.com/eqrion/cbindgen/archive/v$version/$name-v$version.tar.gz)
+
+build() {
+	cd $name-$version
+
+	prt-get isinst sccache && export RUSTC_WRAPPER=/usr/bin/sccache
+	mkdir "$PKGMK_SOURCE_DIR/rust" || true
+	export CARGO_HOME="$PKGMK_SOURCE_DIR/rust"
+
+	cargo fetch --locked --target aarch64-unknown-linux-gnu
+	cargo build --release --frozen --all-targets
+	install -Dt $PKG/usr/bin target/release/cbindgen
+}


### PR DESCRIPTION
we need to specify the correct build arch here for the package to build.