### PR TITLE
add python3-cairo aarch64 specific footprint fix

### DIFF
--- a/python3-cairo/.footprint
+++ b/python3-cairo/.footprint
@@ -1,0 +1,24 @@
+drwxr-xr-x	root/root	usr/
+drwxr-xr-x	root/root	usr/include/
+drwxr-xr-x	root/root	usr/include/pycairo/
+-rw-rw-r--	root/root	usr/include/pycairo/py3cairo.h
+drwxr-xr-x	root/root	usr/lib/
+drwxr-xr-x	root/root	usr/lib/pkgconfig/
+-rw-r--r--	root/root	usr/lib/pkgconfig/py3cairo.pc
+drwxr-xr-x	root/root	usr/lib/python3.10/
+drwxr-xr-x	root/root	usr/lib/python3.10/site-packages/
+drwxr-xr-x	root/root	usr/lib/python3.10/site-packages/cairo/
+-rw-r--r--	root/root	usr/lib/python3.10/site-packages/cairo/__init__.py
+-rw-rw-r--	root/root	usr/lib/python3.10/site-packages/cairo/__init__.pyi
+drwxr-xr-x	root/root	usr/lib/python3.10/site-packages/cairo/__pycache__/
+-rw-r--r--	root/root	usr/lib/python3.10/site-packages/cairo/__pycache__/__init__.cpython-310.opt-1.pyc
+-rw-r--r--	root/root	usr/lib/python3.10/site-packages/cairo/__pycache__/__init__.cpython-310.pyc
+-rwxr-xr-x	root/root	usr/lib/python3.10/site-packages/cairo/_cairo.cpython-310-aarch64-linux-gnu.so
+drwxr-xr-x	root/root	usr/lib/python3.10/site-packages/cairo/include/
+-rw-rw-r--	root/root	usr/lib/python3.10/site-packages/cairo/include/py3cairo.h
+-rw-r--r--	root/root	usr/lib/python3.10/site-packages/cairo/py.typed (EMPTY)
+drwxr-xr-x	root/root	usr/lib/python3.10/site-packages/pycairo-1.23.0-py3.10.egg-info/
+-rw-rw-r--	root/root	usr/lib/python3.10/site-packages/pycairo-1.23.0-py3.10.egg-info/PKG-INFO
+-rw-rw-r--	root/root	usr/lib/python3.10/site-packages/pycairo-1.23.0-py3.10.egg-info/SOURCES.txt
+-rw-rw-r--	root/root	usr/lib/python3.10/site-packages/pycairo-1.23.0-py3.10.egg-info/dependency_links.txt
+-rw-rw-r--	root/root	usr/lib/python3.10/site-packages/pycairo-1.23.0-py3.10.egg-info/top_level.txt

--- a/python3-cairo/.signature
+++ b/python3-cairo/.signature
@@ -1,0 +1,5 @@
+untrusted comment: verify with /etc/ports/opt-arm64.pub
+RWRitF9a2DJqMSyHCuf3zGnOb0m8Y3NooBBtXG4oihv0I/1+JN6sRc/uZzXwLw5cJ1xaniarjpcR2sm+ur/K1YPxTUKaYp2w5AU=
+SHA256 (Pkgfile) = 3336e177029cacba590fc5bba4b763bedee7167e9ffe144ba7505300ea7c94f7
+SHA256 (.footprint) = 8dd0379ba271baa8b233c0dedb700c098f0e821c09f1d5ee89a7ac5c603fdfbe
+SHA256 (pycairo-1.23.0.tar.gz) = 9b61ac818723adc04367301317eb2e814a83522f07bbd1f409af0dada463c44c

--- a/python3-cairo/Pkgfile
+++ b/python3-cairo/Pkgfile
@@ -1,0 +1,16 @@
+# Description: A set of python bindings for cairo.
+# URL: https://pypi.org/project/pycairo/
+# Maintainer: Danny Rawlins, crux at romster dot me
+# Depends on: cairo
+
+name=python3-cairo
+version=1.23.0
+release=1
+source=(https://github.com/pygobject/pycairo/releases/download/v$version/pycairo-$version.tar.gz)
+
+build() {
+	cd pycairo-$version
+
+	/usr/bin/python3 setup.py build
+	/usr/bin/python3 setup.py install --skip-build --root=$PKG --optimize=1
+}


### PR DESCRIPTION
arm64 specific filename change so the built port will install