### PR TITLE
pango: update download url

### DIFF
--- a/pango/Pkgfile
+++ b/pango/Pkgfile
@@ -7,7 +7,7 @@
 name=pango
 version=1.54.0
 release=1
-source=(https://download-fallback.gnome.org/sources/$name/${version:0:4}/$name-$version.tar.xz)
+source=(https://download.gnome.org/sources/$name/${version:0:4}/$name-$version.tar.xz)
 
 build() {
 	meson build $name-$version \


### PR DESCRIPTION
GNOME recently changed their infrastructure and no longer are using the 'download-fallback' sub-domain.

This change fixes the broken source download.